### PR TITLE
Add `linktocpage` option

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -86,8 +86,11 @@ colored-not-bordered-links: true # true = highlight text of links - false = high
 # and comment out the colors below
 urlcolor-rgb: "0,0,139"
 citecolor-rgb: "0,33,71"
-# linkcolor-rgb: "0,33,71"  # coloring normal links looks a bit excessive, as it highlights also all links in the table of contents
+linkcolor-rgb: "0,33,71"
 
+# Make page number, not text, be link in TOC, LOF, and LOT. Otherwise, link
+# highlighting may look a bit excessive.
+link-toc-page: true
 
 ### binding / margins ###
 page-layout: nobind #'nobind' for equal margins (PDF output), 'twoside' for two-sided binding (mirror margins and blank pages), leave blank for one-sided binding (left margin > right margin)

--- a/templates/template.tex
+++ b/templates/template.tex
@@ -52,6 +52,7 @@ $if(colored-not-bordered-links)$
 \hypersetup{
   hidelinks,
   colorlinks,
+  linktocpage=$if(link-toc-page)$$link-toc-page$$else$true$endif$,
   linkcolor=$if(linkcolor-rgb)$mylinkcolor$else$.$endif$,
   urlcolor=$if(urlcolor-rgb)$myurlcolor$else$.$endif$,
   citecolor=$if(citecolor-rgb)$mycitecolor$else$.$endif$
@@ -60,6 +61,7 @@ $if(colored-not-bordered-links)$
 $else$
 \hypersetup{
   colorlinks=false,
+  linktocpage=$if(link-toc-page)$$link-toc-page$$else$true$endif$,
   linkbordercolor=$if(linkcolor-rgb)$mylinkcolor$else$.$endif$,
   urlbordercolor=$if(urlcolor-rgb)$myurlcolor$else$.$endif$,
   citebordercolor=$if(citecolor-rgb)$mycitecolor$else$.$endif$


### PR DESCRIPTION
- Highlights the page numbers instead of text in TOC, LOF, and LOT.

- `true` is the default both in the YAML option as well as if the option is not
specified in the YAML.

- For https://github.com/ulyngs/oxforddown/issues/26