### PR TITLE
Only show abstract if provided

### DIFF
--- a/templates/template.tex
+++ b/templates/template.tex
@@ -333,9 +333,11 @@ $endif$
 
 
 %%%%% ABSTRACT -- Nothing to do here except comment out if you don't want it.
+$if(abstract)$
 \begin{abstract}
 	$abstract$
 \end{abstract}
+$endif$
 
 %%%%% MINI TABLES
 % This lays the groundwork for per-chapter, mini tables of contents.  Comment the following line


### PR DESCRIPTION
This matches the behaviour of other options, including `dedication` and `acknowledgements`.