### PR TITLE
Add \phantomsection to make TOC link correctly

### DIFF
--- a/templates/template.tex
+++ b/templates/template.tex
@@ -373,6 +373,7 @@ $endif$
 $if(acknowledgements)$
 
 $if(show-acknowledgements-in-toc)$
+\phantomsection
 \addcontentsline{toc}{chapter}{Acknowledgements}
 \renewcommand{\numberstyleacks}{plain}
 \renewcommand{\numberstyleabstract}{plain}
@@ -389,7 +390,7 @@ $endif$
 $if(abstract)$
 
 $if(show-abstract-in-toc)$
-
+\phantomsection
 \addcontentsline{toc}{chapter}{$if(abstract-heading)$$abstract-heading$$else$Abstract$endif$}
 \renewcommand{\numberstyleabstract}{plain}
 $endif$
@@ -402,7 +403,7 @@ $endif$
 $endif$
 
 $if(abstract-second)$
-
+\phantomsection
 $if(show-abstract-in-toc)$
 \addcontentsline{toc}{chapter}{$abstract-second-heading$}
 \renewcommand{\numberstyleabstract}{plain}


### PR DESCRIPTION
I needed to add `\phantomsection` before `\addcontentsline{toc}{chapter}{Acknowledgements}` for both acknowledgements and both abstracts to make the TOC link the the correct pages. Otherwise they link to the chapter before.

There may be better solutions than the one provided in this PR.